### PR TITLE
Refactor cleanup

### DIFF
--- a/icmp_test.go
+++ b/icmp_test.go
@@ -84,7 +84,7 @@ func TestICMPNeighborAdvertisement(t *testing.T) {
 		t.Errorf("fixture of %v did not match %v", fixture, marshal)
 	}
 
-	descfix = "neighbor advertisement, length 32, tgt is fe80::1, Flags [router solicited override]\n    target link-layer Address option (2), length 8 (1): a1:b2:c3:d4:e5:f6"
+	descfix = "neighbor advertisement, length 32, tgt is fe80::1, Flags [router solicited override]\n    target link-layer address option (2), length 8 (1): a1:b2:c3:d4:e5:f6"
 	desc = icmp.String()
 	if strings.Compare(desc, descfix) != 0 {
 		t.Errorf("fixture of '%s' did not match '%s'", descfix, desc)

--- a/icmp_test.go
+++ b/icmp_test.go
@@ -66,7 +66,7 @@ func TestICMPNeighborAdvertisement(t *testing.T) {
 	}
 
 	// add option
-	option := NewICMPOption(ICMPOptionTypeTargetLinkLayerAddress).(*ICMPOptionTargetLinkLayerAddress)
+	option := &ICMPOptionTargetLinkLayerAddress{}
 	option.LinkLayerAddress, err = net.ParseMAC("a1:b2:c3:d4:e5:f6")
 	if err != nil {
 		t.Error(err)
@@ -145,7 +145,7 @@ func TestICMPNeighborSolicitation(t *testing.T) {
 	}
 
 	// add option
-	option := NewICMPOption(ICMPOptionTypeSourceLinkLayerAddress).(*ICMPOptionSourceLinkLayerAddress)
+	option := &ICMPOptionSourceLinkLayerAddress{}
 	option.LinkLayerAddress, err = net.ParseMAC("a1:b2:c3:d4:e5:f6")
 	if err != nil {
 		t.Error(err)
@@ -192,8 +192,9 @@ func TestICMPNeighborSolicitation(t *testing.T) {
 	}
 
 	// replace options with Nonce option
-	nonce := NewICMPOption(ICMPOptionTypeNonce).(*ICMPOptionNonce)
-	nonce.Nonce = 65766764768057 // 3bd0 84a6 eb39
+	nonce := &ICMPOptionNonce{
+		Nonce: 65766764768057, // 3bd0 84a6 eb39
+	}
 	icmp.Options = []ICMPOption{nonce}
 
 	marshal, err = icmp.Marshal()
@@ -258,7 +259,7 @@ func TestICMPRouterSolicitation(t *testing.T) {
 	}
 
 	// add option
-	option := NewICMPOption(ICMPOptionTypeSourceLinkLayerAddress).(*ICMPOptionSourceLinkLayerAddress)
+	option := &ICMPOptionSourceLinkLayerAddress{}
 	option.LinkLayerAddress, err = net.ParseMAC("a1:b2:c3:d4:e5:f6")
 	if err != nil {
 		t.Error(err)
@@ -387,9 +388,13 @@ func TestICMPRouterAdvertisement(t *testing.T) {
 	}
 
 	// add RDNSS option
-	dnssOption := NewICMPOption(ICMPOptionTypeRecursiveDNSServer).(*ICMPOptionRecursiveDNSServer)
-	dnssOption.Lifetime = 300
-	dnssOption.Servers = []net.IP{net.ParseIP("2001:4860:4860::8844"), net.ParseIP("2001:4860:4860::8888")}
+	dnssOption := &ICMPOptionRecursiveDNSServer{
+		Lifetime: 300,
+		Servers: []net.IP{
+			net.ParseIP("2001:4860:4860::8844"),
+			net.ParseIP("2001:4860:4860::8888"),
+		},
+	}
 
 	icmp.AddOption(dnssOption)
 
@@ -424,10 +429,10 @@ func TestICMPRouterAdvertisement(t *testing.T) {
 	}
 
 	// add DNSSL option
-	dnsslOption := NewICMPOption(ICMPOptionTypeDNSSearchList).(*ICMPOptionDNSSearchList)
-	dnsslOption.Lifetime = 10
-	dnsslOption.DomainNames = []string{"basement.golang.org."}
-
+	dnsslOption := &ICMPOptionDNSSearchList{
+		Lifetime:    10,
+		DomainNames: []string{"basement.golang.org."},
+	}
 	icmp.AddOption(dnsslOption)
 
 	marshal, err = icmp.Marshal()
@@ -441,8 +446,9 @@ func TestICMPRouterAdvertisement(t *testing.T) {
 	}
 
 	// add MTU option
-	mtuOption := NewICMPOption(ICMPOptionTypeMTU).(*ICMPOptionMTU)
-	mtuOption.MTU = 1500
+	mtuOption := &ICMPOptionMTU{
+		MTU: 1500,
+	}
 	icmp.AddOption(mtuOption)
 
 	marshal, err = icmp.Marshal()
@@ -509,8 +515,9 @@ func TestChecksum(t *testing.T) {
 	}
 
 	// add MTU option
-	mtuOption := NewICMPOption(ICMPOptionTypeMTU).(*ICMPOptionMTU)
-	mtuOption.MTU = 1500
+	mtuOption := &ICMPOptionMTU{
+		MTU: 1500,
+	}
 	msg.AddOption(mtuOption)
 
 	marshal, err = msg.Marshal()

--- a/icmp_test.go
+++ b/icmp_test.go
@@ -10,13 +10,6 @@ import (
 	"golang.org/x/net/ipv6"
 )
 
-func TestNewICMP(t *testing.T) {
-	msg := NewICMP(ipv6.ICMPTypeEchoRequest)
-	if msg != nil {
-		t.Error("unexpected handled type")
-	}
-}
-
 func TestParseMessage(t *testing.T) {
 	_, err := ParseMessage([]byte{0, 0, 0})
 	if err != errMessageTooShort {
@@ -31,11 +24,12 @@ func TestParseMessage(t *testing.T) {
 }
 
 func TestICMPNeighborAdvertisement(t *testing.T) {
-	icmp := NewICMP(ipv6.ICMPTypeNeighborAdvertisement).(*ICMPNeighborAdvertisement)
-	icmp.Router = true
-	icmp.Solicited = true
-	icmp.Override = true
-	icmp.TargetAddress = net.ParseIP("fe80::1")
+	icmp := &ICMPNeighborAdvertisement{
+		Router:        true,
+		Solicited:     true,
+		Override:      true,
+		TargetAddress: net.ParseIP("fe80::1"),
+	}
 
 	if icmp.Type() != ipv6.ICMPTypeNeighborAdvertisement {
 		t.Errorf("wrong type: %d instead of %d", icmp.Type(), ipv6.ICMPTypeNeighborAdvertisement)
@@ -112,8 +106,9 @@ func TestICMPNeighborAdvertisement(t *testing.T) {
 }
 
 func TestICMPNeighborSolicitation(t *testing.T) {
-	icmp := NewICMP(ipv6.ICMPTypeNeighborSolicitation).(*ICMPNeighborSolicitation)
-	icmp.TargetAddress = net.ParseIP("fe80::1")
+	icmp := &ICMPNeighborSolicitation{
+		TargetAddress: net.ParseIP("fe80::1"),
+	}
 
 	if icmp.Type() != ipv6.ICMPTypeNeighborSolicitation {
 		t.Errorf("wrong type: %d instead of %d", icmp.Type(), ipv6.ICMPTypeNeighborSolicitation)
@@ -226,7 +221,7 @@ func TestICMPNeighborSolicitation(t *testing.T) {
 }
 
 func TestICMPRouterSolicitation(t *testing.T) {
-	icmp := NewICMP(ipv6.ICMPTypeRouterSolicitation).(*ICMPRouterSolicitation)
+	icmp := &ICMPRouterSolicitation{}
 
 	if icmp.Type() != ipv6.ICMPTypeRouterSolicitation {
 		t.Errorf("wrong type: %d instead of %d", icmp.Type(), ipv6.ICMPTypeRouterSolicitation)
@@ -311,14 +306,15 @@ func TestICMPRouterSolicitation(t *testing.T) {
 }
 
 func TestICMPRouterAdvertisement(t *testing.T) {
-	icmp := NewICMP(ipv6.ICMPTypeRouterAdvertisement).(*ICMPRouterAdvertisement)
-	icmp.HopLimit = 64
-	icmp.ManagedAddress = true
-	icmp.OtherStateful = true
-	icmp.HomeAgent = true
-	icmp.RouterLifeTime = 3600
-	icmp.ReachableTime = 7200
-	icmp.RetransTimer = 1800
+	icmp := &ICMPRouterAdvertisement{
+		HopLimit:       64,
+		ManagedAddress: true,
+		OtherStateful:  true,
+		HomeAgent:      true,
+		RouterLifeTime: 3600,
+		ReachableTime:  7200,
+		RetransTimer:   1800,
+	}
 
 	if icmp.Type() != ipv6.ICMPTypeRouterAdvertisement {
 		t.Errorf("wrong type: %d instead of %d", icmp.Type(), ipv6.ICMPTypeRouterAdvertisement)
@@ -484,11 +480,12 @@ func TestICMPRouterAdvertisement(t *testing.T) {
 
 func TestChecksum(t *testing.T) {
 	// prepare icmp message
-	msg := NewICMP(ipv6.ICMPTypeRouterAdvertisement).(*ICMPRouterAdvertisement)
-	msg.HopLimit = 64
-	msg.OtherStateful = true
-	msg.RouterLifeTime = 3600
-	msg.RouterPreference = RouterPreferenceHigh
+	msg := &ICMPRouterAdvertisement{
+		HopLimit:         64,
+		OtherStateful:    true,
+		RouterLifeTime:   3600,
+		RouterPreference: RouterPreferenceHigh,
+	}
 
 	marshal, err := msg.Marshal()
 	if err != nil {

--- a/icmpoption.go
+++ b/icmpoption.go
@@ -7,6 +7,25 @@ import (
 	"strings"
 )
 
+// ICMPOptions is a type wrapper for a slice of ICMPOptions
+type ICMPOptions []ICMPOption
+
+// Marshal is a helper function of ICMPOptions and returns marshalled results
+// for all ICMPOptions or error when there is one
+func (opts ICMPOptions) Marshal() ([]byte, error) {
+	var b []byte
+	for _, o := range opts {
+		m, err := o.Marshal()
+		if err != nil {
+			return nil, err
+		}
+
+		b = append(b, m...)
+	}
+
+	return b, nil
+}
+
 type ICMPOptionType int
 
 func (typ ICMPOptionType) String() string {

--- a/icmpoption.go
+++ b/icmpoption.go
@@ -26,38 +26,44 @@ func (opts ICMPOptions) Marshal() ([]byte, error) {
 	return b, nil
 }
 
+// ICMPOptionType describes ICMPv6 types
 type ICMPOptionType int
 
-func (typ ICMPOptionType) String() string {
-	s, ok := icmpOptionTypes[typ]
-	if !ok {
-		return "<nil>"
-	}
-
-	return s
-}
-
+// ICMPv6 Neighbor discovery types as described in RFC4861, RFC3971, RFC6106
 const (
-	ICMPOptionTypeSourceLinkLayerAddress ICMPOptionType = 1
-	ICMPOptionTypeTargetLinkLayerAddress ICMPOptionType = 2
-	ICMPOptionTypePrefixInformation      ICMPOptionType = 3
-	ICMPOptionTypeMTU                    ICMPOptionType = 5
-	ICMPOptionTypeNonce                  ICMPOptionType = 14
-	ICMPOptionTypeRecursiveDNSServer     ICMPOptionType = 25
-	ICMPOptionTypeDNSSearchList          ICMPOptionType = 31
+	_ ICMPOptionType = iota
+	// RFC4861
+	ICMPOptionTypeSourceLinkLayerAddress
+	ICMPOptionTypeTargetLinkLayerAddress
+	ICMPOptionTypePrefixInformation
+	_
+	ICMPOptionTypeMTU
+	// RFC3971
+	ICMPOptionTypeNonce ICMPOptionType = 14
+	// RFC6106
+	ICMPOptionTypeRecursiveDNSServer ICMPOptionType = 25
+	ICMPOptionTypeDNSSearchList      ICMPOptionType = 31
 )
 
-var icmpOptionTypes = map[ICMPOptionType]string{
-	// https://tools.ietf.org/html/rfc4861#section-4.6
-	1: "source link-layer address",
-	2: "target link-layer Address",
-	3: "prefix info",
-	5: "mtu",
-	// https://tools.ietf.org/html/rfc3971#section-5
-	14: "nonce",
-	// https://tools.ietf.org/html/rfc6106#section-5
-	25: "rdnss",
-	31: "dnssl",
+func (t ICMPOptionType) String() string {
+	switch t {
+	case ICMPOptionTypeSourceLinkLayerAddress:
+		return "source link-layer address"
+	case ICMPOptionTypeTargetLinkLayerAddress:
+		return "target link-layer address"
+	case ICMPOptionTypePrefixInformation:
+		return "prefix info"
+	case ICMPOptionTypeMTU:
+		return "mtu"
+	case ICMPOptionTypeNonce:
+		return "nonce"
+	case ICMPOptionTypeRecursiveDNSServer:
+		return "rdnss"
+	case ICMPOptionTypeDNSSearchList:
+		return "dnssl"
+	default:
+		return "<nil>"
+	}
 }
 
 type ICMPOption interface {
@@ -490,7 +496,7 @@ func parseOptions(b []byte) ([]ICMPOption, error) {
 		switch optionType {
 		case ICMPOptionTypeSourceLinkLayerAddress:
 			if optionLength != 1 {
-				return nil, fmt.Errorf("option %s (%d) too short: %d should be 1", icmpOptionTypes[optionType], optionType, optionLength)
+				return nil, fmt.Errorf("option %s (%d) too short: %d should be 1", optionType, optionType, optionLength)
 			}
 
 			currentOption = &ICMPOptionSourceLinkLayerAddress{
@@ -502,7 +508,7 @@ func parseOptions(b []byte) ([]ICMPOption, error) {
 
 		case ICMPOptionTypeTargetLinkLayerAddress:
 			if optionLength != 1 {
-				return nil, fmt.Errorf("option %s (%d) too short: %d should be 1", icmpOptionTypes[optionType], optionType, optionLength)
+				return nil, fmt.Errorf("option %s (%d) too short: %d should be 1", optionType, optionType, optionLength)
 			}
 
 			currentOption = &ICMPOptionTargetLinkLayerAddress{
@@ -514,7 +520,7 @@ func parseOptions(b []byte) ([]ICMPOption, error) {
 
 		case ICMPOptionTypePrefixInformation:
 			if optionLength != 4 {
-				return nil, fmt.Errorf("option %s (%d) too short: %d should be 4", icmpOptionTypes[optionType], optionType, optionLength)
+				return nil, fmt.Errorf("option %s (%d) too short: %d should be 4", optionType, optionType, optionLength)
 			}
 
 			currentOption = &ICMPOptionPrefixInformation{
@@ -531,7 +537,7 @@ func parseOptions(b []byte) ([]ICMPOption, error) {
 
 		case ICMPOptionTypeMTU:
 			if optionLength != 1 {
-				return nil, fmt.Errorf("option %s (%d) too short: %d should be 1", icmpOptionTypes[optionType], optionType, optionLength)
+				return nil, fmt.Errorf("option %s (%d) too short: %d should be 1", optionType, optionType, optionLength)
 			}
 
 			currentOption = &ICMPOptionMTU{
@@ -543,7 +549,7 @@ func parseOptions(b []byte) ([]ICMPOption, error) {
 
 		case ICMPOptionTypeNonce:
 			if optionLength != 1 {
-				return nil, fmt.Errorf("option %s (%d) too short: %d should be 1", icmpOptionTypes[optionType], optionType, optionLength)
+				return nil, fmt.Errorf("option %s (%d) too short: %d should be 1", optionType, optionType, optionLength)
 			}
 
 			currentOption = &ICMPOptionNonce{
@@ -558,7 +564,7 @@ func parseOptions(b []byte) ([]ICMPOption, error) {
 
 		case ICMPOptionTypeRecursiveDNSServer:
 			if optionLength < 3 {
-				return nil, fmt.Errorf("option %s (%d) too short: %d should at least be 3", icmpOptionTypes[optionType], optionType, optionLength)
+				return nil, fmt.Errorf("option %s (%d) too short: %d should at least be 3", optionType, optionType, optionLength)
 			}
 
 			currentOption = &ICMPOptionRecursiveDNSServer{
@@ -577,7 +583,7 @@ func parseOptions(b []byte) ([]ICMPOption, error) {
 
 		case ICMPOptionTypeDNSSearchList:
 			if optionLength < 4 {
-				return nil, fmt.Errorf("option %s (%d) too short: %d should at least be 4", icmpOptionTypes[optionType], optionType, optionLength)
+				return nil, fmt.Errorf("option %s (%d) too short: %d should at least be 4", optionType, optionType, optionLength)
 			}
 
 			currentOption = &ICMPOptionDNSSearchList{
@@ -598,7 +604,7 @@ func parseOptions(b []byte) ([]ICMPOption, error) {
 		}
 
 		if optionLength != currentOption.Len() {
-			return nil, fmt.Errorf("length mismatch while parsing %s: %d should be %d", icmpOptionTypes[optionType], currentOption.Len(), optionLength)
+			return nil, fmt.Errorf("length mismatch while parsing %s: %d should be %d", optionType, currentOption.Len(), optionLength)
 		}
 
 		// add new option to array of options

--- a/icmpoption_test.go
+++ b/icmpoption_test.go
@@ -30,9 +30,10 @@ func TestICMPOptionTypeString(t *testing.T) {
 }
 
 func TestICMPOptionDNSSearchList(t *testing.T) {
-	option := NewICMPOption(ICMPOptionTypeDNSSearchList).(*ICMPOptionDNSSearchList)
-	option.Lifetime = 10
-	option.DomainNames = []string{"basement.golang.org."}
+	option := &ICMPOptionDNSSearchList{
+		Lifetime:    10,
+		DomainNames: []string{"basement.golang.org."},
+	}
 
 	if option.Type() != ICMPOptionTypeDNSSearchList {
 		t.Errorf("wrong type: %d instead of %d", option.Type(), ICMPOptionTypeDNSSearchList)
@@ -123,8 +124,9 @@ func TestICMPOptionDNSSearchList(t *testing.T) {
 }
 
 func TestICMPOptionMTU(t *testing.T) {
-	option := NewICMPOption(ICMPOptionTypeMTU).(*ICMPOptionMTU)
-	option.MTU = 1500
+	option := &ICMPOptionMTU{
+		MTU: 1500,
+	}
 
 	if option.Type() != ICMPOptionTypeMTU {
 		t.Errorf("wrong type: %d instead of %d", option.Type(), ICMPOptionTypeMTU)
@@ -174,8 +176,9 @@ func TestICMPOptionMTU(t *testing.T) {
 }
 
 func TestICMPOptionNonce(t *testing.T) {
-	option := NewICMPOption(ICMPOptionTypeNonce).(*ICMPOptionNonce)
-	option.Nonce = 65766764768057
+	option := &ICMPOptionNonce{
+		Nonce: 65766764768057,
+	}
 
 	if option.Type() != ICMPOptionTypeNonce {
 		t.Errorf("wrong type: %d instead of %d", option.Type(), ICMPOptionTypeNonce)
@@ -231,7 +234,7 @@ func TestICMPOptionNonce(t *testing.T) {
 
 func TestICMPOptionSourceLinkLayerAddress(t *testing.T) {
 	var err error
-	option := NewICMPOption(ICMPOptionTypeSourceLinkLayerAddress).(*ICMPOptionSourceLinkLayerAddress)
+	option := &ICMPOptionSourceLinkLayerAddress{}
 	option.LinkLayerAddress, err = net.ParseMAC("a1:b2:c3:d4:e6:f7")
 	if err != nil {
 		t.Error(err)
@@ -286,7 +289,7 @@ func TestICMPOptionSourceLinkLayerAddress(t *testing.T) {
 
 func TestICMPOptionTargetLinkLayerAddress(t *testing.T) {
 	var err error
-	option := NewICMPOption(ICMPOptionTypeTargetLinkLayerAddress).(*ICMPOptionTargetLinkLayerAddress)
+	option := &ICMPOptionTargetLinkLayerAddress{}
 	option.LinkLayerAddress, err = net.ParseMAC("a1:b2:c3:d4:e6:f7")
 	if err != nil {
 		t.Error(err)
@@ -340,13 +343,14 @@ func TestICMPOptionTargetLinkLayerAddress(t *testing.T) {
 }
 
 func TestICMPOptionPrefixInformation(t *testing.T) {
-	option := NewICMPOption(ICMPOptionTypePrefixInformation).(*ICMPOptionPrefixInformation)
-	option.PrefixLength = 64
-	option.OnLink = true
-	option.Auto = true
-	option.ValidLifetime = 2592000
-	option.PreferredLifetime = 604800
-	option.Prefix = net.ParseIP("2a00:1450:400e:802::")
+	option := &ICMPOptionPrefixInformation{
+		PrefixLength:      64,
+		OnLink:            true,
+		Auto:              true,
+		ValidLifetime:     2592000,
+		PreferredLifetime: 604800,
+		Prefix:            net.ParseIP("2a00:1450:400e:802::"),
+	}
 
 	if option.Type() != ICMPOptionTypePrefixInformation {
 		t.Errorf("wrong type: %d instead of %d", option.Type(), ICMPOptionTypePrefixInformation)
@@ -396,9 +400,10 @@ func TestICMPOptionPrefixInformation(t *testing.T) {
 }
 
 func TestICMPOptionRecursiveDNSServer(t *testing.T) {
-	option := NewICMPOption(ICMPOptionTypeRecursiveDNSServer).(*ICMPOptionRecursiveDNSServer)
-	option.Lifetime = 300
-	option.Servers = []net.IP{net.ParseIP("2001:4860:4860::8844")}
+	option := &ICMPOptionRecursiveDNSServer{
+		Lifetime: 300,
+		Servers:  []net.IP{net.ParseIP("2001:4860:4860::8844")},
+	}
 
 	if option.Type() != ICMPOptionTypeRecursiveDNSServer {
 		t.Errorf("wrong type: %d instead of %d", option.Type(), ICMPOptionTypeRecursiveDNSServer)

--- a/icmpoption_test.go
+++ b/icmpoption_test.go
@@ -7,6 +7,28 @@ import (
 	"testing"
 )
 
+func TestICMPOptionTypeString(t *testing.T) {
+	tests := []struct {
+		in  ICMPOptionType
+		out string
+	}{
+		{0, "<nil>"},
+		{ICMPOptionTypeSourceLinkLayerAddress, "source link-layer address"},
+		{ICMPOptionTypeTargetLinkLayerAddress, "target link-layer address"},
+		{ICMPOptionTypePrefixInformation, "prefix info"},
+		{ICMPOptionTypeMTU, "mtu"},
+		{ICMPOptionTypeNonce, "nonce"},
+		{ICMPOptionTypeRecursiveDNSServer, "rdnss"},
+		{ICMPOptionTypeDNSSearchList, "dnssl"},
+	}
+
+	for _, test := range tests {
+		if strings.Compare(test.in.String(), test.out) != 0 {
+			t.Errorf("expected %s but got %s", test.out, test.in.String())
+		}
+	}
+}
+
 func TestICMPOptionDNSSearchList(t *testing.T) {
 	option := NewICMPOption(ICMPOptionTypeDNSSearchList).(*ICMPOptionDNSSearchList)
 	option.Lifetime = 10
@@ -290,7 +312,7 @@ func TestICMPOptionTargetLinkLayerAddress(t *testing.T) {
 		t.Errorf("fixture of %v did not match %v", fixture, marshal)
 	}
 
-	descfix := "target link-layer Address option (2), length 8 (1): a1:b2:c3:d4:e6:f7"
+	descfix := "target link-layer address option (2), length 8 (1): a1:b2:c3:d4:e6:f7"
 	desc := option.String()
 	if strings.Compare(desc, descfix) != 0 {
 		t.Errorf("fixture of '%s' did not match '%s'", descfix, desc)


### PR DESCRIPTION
- improved test coverage
- improved descriptions and comments
- made `ICMPBase`, `NewICMP()`, `ICMPOptionBase` and `NewICMPOption()` obsolete
- generally cleaned code